### PR TITLE
DEVOPS-4330: support CI Pipeline tagging in Datadog

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,12 +17,13 @@ permissions:
 jobs:
   build:
     uses: finix-payments/finix-github-actions/.github/workflows/build-nodejs-project.yaml@main
-    with: 
+    with:
       run_node_tests: false
+    secrets: inherit
   deploy:
-    needs: 
+    needs:
       - build
     uses: finix-payments/finix-github-actions/.github/workflows/publish-to-finix-cdn.yaml@main
-    with: 
+    with:
       environment: ${{ inputs.environment }}
       s3_path: "accept-a-payment-${{ inputs.environment }}"


### PR DESCRIPTION
This change gives the reusable workflows access to datadog keys that
are used to tag ci pipeline data and are saved as organizational secrets
