### PR TITLE
FE-5643 Update Apple Pay button used to support new library

### DIFF
--- a/src/app/components/ApplePayButton.css
+++ b/src/app/components/ApplePayButton.css
@@ -1,16 +1,13 @@
-.apple-pay-button {
-  display: inline-block;
-  appearance: -apple-pay-button;
-  -webkit-appearance: -apple-pay-button;
-  -apple-pay-button-style: black;
-  height: 45px;
+apple-pay-button {
+  --apple-pay-button-width: 250px;
+  --apple-pay-button-height: 45px;
+  --apple-pay-button-border-radius: 3px;
+  --apple-pay-button-padding: 0px 0px;
+  --apple-pay-button-box-sizing: border-box;
   margin-top: 0.5rem;
-  width: 250px;
-  /* -apple-pay-button-type: check-out; */
-  font-size: 1rem;
-  color: pink;
+  display: inline-block;
 }
 
-.apple-pay-button:hover {
+apple-pay-button:hover {
   cursor: pointer;
 }

--- a/src/app/components/ApplePayButton.tsx
+++ b/src/app/components/ApplePayButton.tsx
@@ -197,13 +197,18 @@ const ApplePay: React.FC<ApplePayProps> = ({
   }
 
   return (
-    <div 
-      className="w-full" 
-      data-inspectable 
-      data-component="ApplePay" 
+    <div
+      className="w-full"
+      data-inspectable
+      data-component="ApplePay"
       data-code={applePayButtonCode}
     >
-      <div className="apple-pay-button" onClick={startApplePaySession} />
+      <apple-pay-button
+        buttonstyle="black"
+        type="buy"
+        locale="en-US"
+        onclick={startApplePaySession}
+      />
     </div>
   );
 };

--- a/src/app/components/inspector/code/ApplePayButtonCode.ts
+++ b/src/app/components/inspector/code/ApplePayButtonCode.ts
@@ -114,7 +114,19 @@ const ApplePayButton: React.FC<ApplePayProps> = ({
   }
 
   return (
-    <div className="apple-pay-button" onClick={startApplePaySession} />
+    <div
+      className="w-full"
+      data-inspectable
+      data-component="ApplePay"
+      data-code={applePayButtonCode}
+    >
+      <apple-pay-button
+        buttonstyle="black"
+        type="buy"
+        locale="en-US"
+        onclick={startApplePaySession}
+      />
+    </div>
   );
 };
 


### PR DESCRIPTION
## General Overview
This PR updates the Apple Pay button in our sample app. This follows the new button style [recommended by Apple](https://applepaydemo.apple.com/) as it will render on different browsers.

## Testing Steps
This isn't possible for us to test locally. Apple Pay requires https, and even with ngrok there are a few barriers to testing. I would just check that the tokenization form continues to load correctly, and the Apple Pay script is present when you inspect element.

